### PR TITLE
Make discovery quiet by default

### DIFF
--- a/lib/DaikinDiscovery.js
+++ b/lib/DaikinDiscovery.js
@@ -6,6 +6,9 @@
 
 var udp = require("dgram");
 
+// Change this to true to output debugging logs to the console
+var debug = false;
+
 // TODO: Which parameterrs are really needed
 // TODO: Also initialize DaicinAC instances?
 function discover(waitForCount, callback) {
@@ -15,15 +18,16 @@ function discover(waitForCount, callback) {
     var probeAddress='255.255.255.255';
     var probeAttempts=10;
     var probeInterval=500;
-    var probeData = new Buffer('DAIKIN_UDP/common/basic_info');
+    var probeData = new Buffer.from('DAIKIN_UDP/common/basic_info');
     var probeTimeout;
+    
 
     var discoveredDevices = {};
 
     var udpSocket = udp.createSocket({type:"udp4", reuseAddr:true});
 
     udpSocket.on('error', function (err) {
-        console.log('ERROR udpSocket: ' + err);
+        if (debug) console.log('ERROR udpSocket: ' + err);
     });
 
     udpSocket.bind(listenPort, listenAddress, function() {
@@ -32,7 +36,7 @@ function discover(waitForCount, callback) {
     });
 
     udpSocket.on("message", function (message, remote) {
-        console.log(remote.address + ':' + remote.port +' - ' + message);
+        if (debug) console.log(remote.address + ':' + remote.port +' - ' + message);
         discoveredDevices[remote.address] = message.toString();
         if (Object.keys(discoveredDevices).length >= waitForCount) {
             finalizeDiscovery();
@@ -46,7 +50,7 @@ function discover(waitForCount, callback) {
     function sendProbes(attemptsLeft) {
         probeTimeout = null;
         if (attemptsLeft > 0) {
-            console.log('Send UDP discovery package ' + attemptsLeft);
+            if (debug) console.log('Send UDP discovery package ' + attemptsLeft);
             udpSocket.send(probeData, 0, probeData.length, probePort, probeAddress);
             probeTimeout = setTimeout(sendProbes, probeInterval, --attemptsLeft);
         }
@@ -58,7 +62,7 @@ function discover(waitForCount, callback) {
     function finalizeDiscovery() {
         if (probeTimeout) clearTimeout(probeTimeout);
         udpSocket.close();
-        console.log('Discovery finished with ' + Object.keys(discoveredDevices).length + ' devices found');
+        if (debug) console.log('Discovery finished with ' + Object.keys(discoveredDevices).length + ' devices found');
         callback(discoveredDevices);
     }
 }


### PR DESCRIPTION
I added a global `debug` flag to the discovery file so that it would be quiet by default. A developer can easily switch `var debug = true` at the top of `lib/DaikinDiscovery.js` to renable it. Seemed like the least intrusive way to make discovery more polite when embedded in a larger project that has custom loggers.

I also fixed the `Buffer()` deprecation warning by switching to `Bufffer.from()`. Seem to work exactly the same as before with my seven Daikin devices, but feel free to pull that out before you merge.

Signed-off-by: Avi Miller <me@dje.li>