### PR TITLE
Improve response parser: It failed when a property contained a comma

### DIFF
--- a/lib/DaikinACRequest.js
+++ b/lib/DaikinACRequest.js
@@ -302,17 +302,15 @@ DaikinACRequest.prototype.doPost = function doPost(url, parameters, callback) {
 };
 
 function parseResponse(input, endpoint, callback) {
-	// Daikin systems respond with HTTP response strings, not JSON objects. JSON is much easier to
-	// parse, so we convert it with some RegExp here.
 
-    function escapeRegExp(str) {
-    	return str.replace(/([.*+?^=!:${}()|\[\]\/\\]\")/g, "\\$1");
-    	// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_Special_Characters
-    }
-
-    function replaceAll(str, find, replace) {
-    	return str.replace(new RegExp(escapeRegExp(find), 'g'), replace);
-    	// From http://stackoverflow.com/a/1144788
+    function parseDaikinResponse(s) {
+        const regex = /(?:^|,)([a-zA-Z0-9_]+)=(.*?)(?=$|,([a-zA-Z0-9_]+)=)/g;
+        let match;
+        let result = {};
+        while(match = regex.exec(s)) {
+            result[match[1]] = match[2];
+        }
+        return result;
     }
 
     var ret = null;
@@ -324,14 +322,11 @@ function parseResponse(input, endpoint, callback) {
     if (Buffer.isBuffer(input)) {
         input = input.toString();
     }
-	var input2 = replaceAll(input, "\=", "\":\"");
-	input2 = replaceAll(input2, ",", "\",\"");
 
-    try {
-        responseData = JSON.parse("{\"" + input2 + "\"}");
-    }
-    catch (e) {
-        callback('Cannot parse response: ' + input2, null, null);
+    if (input.includes('=')) {
+        responseData = parseDaikinResponse(input);
+    } else {
+        callback('Cannot parse response: ' + input, null, null);
         return;
     }
 

--- a/test/testDaikinAC.js
+++ b/test/testDaikinAC.js
@@ -16,7 +16,7 @@ describe('Test DaikinAC', function() {
     it('constructor without update', function (done) {
         var req =   nock('http://127.0.0.1')
                     .get('/common/basic_info')
-                    .reply(200, 'ret=OK,type=aircon,reg=eu,dst=1,ver=2_6_0,pow=0,err=0,location=0,name=%4b%6c%69%6d%61%20%4a%61%6e%61,icon=0,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=2,pv=0,cpv=0,cpv_minor=00,led=0,en_setzone=1,mac=A408EACC91D4,adp_mode=run,en_hol=0,grp_name=%4b%69%6e%64%65%72,en_grp=1')
+                    .reply(200, 'ret=OK,type=aircon,reg=eu,dst=1,ver=2_6_0,pow=0,err=0,location=0,name=%4b%6c%69%6d%61%20%4a%61%6e%61,icon=0,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=2,pv=0,cpv=0,cpv_minor=00,led=0,en_setzone=1,mac=A408EACC91D4,adp_mode=run,en_hol=0,grp_name=%4b%69%6e%64%65%72,en_grp=1,ssid1=(/) (°,,°) (/)')
                     .get('/aircon/get_model_info')
                     .reply(200, 'ret=OK,model=NOTSUPPORT,type=N,pv=0,cpv=0,mid=NA,s_fdir=1,en_scdltmr=1');
         var daikin = new DaikinAC('127.0.0.1', options, function(err, res) {


### PR DESCRIPTION
When a property in the response from the a/c contained a comma, parsing failed. Apparently people have commas in there WiFi-SSID ;-). This fixes that.

See also:
https://github.com/yankee42/node-red-contrib-daikin-ac/issues/1