### PR TITLE
Add support to read demand control data

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout code

--- a/src/DaikinAC.ts
+++ b/src/DaikinAC.ts
@@ -12,6 +12,7 @@ import {
     YearPowerResponse,
 } from './models';
 import { DaikinACOptions, DaikinACRequest, Logger } from './DaikinACRequest';
+import { DemandControl } from './models/DemandControl';
 
 export * from './DaikinACTypes';
 
@@ -24,6 +25,9 @@ export class DaikinAC {
     }
     get currentACControlInfo(): ControlInfo | null {
         return this._currentACControlInfo;
+    }
+    get currentACDemandControl(): DemandControl | null {
+        return this._currentACDemandControl;
     }
     get currentACSensorInfo(): SensorInfoResponse | null {
         return this._currentACSensorInfo;
@@ -46,6 +50,7 @@ export class DaikinAC {
 
     private _currentACModelInfo: null | ModelInfoResponse = null;
     private _currentACControlInfo: null | ControlInfo = null;
+    private _currentACDemandControl: null | DemandControl = null;
     private _currentACSensorInfo: null | SensorInfoResponse = null;
 
     private _logger: null | Logger;
@@ -104,9 +109,16 @@ export class DaikinAC {
                 if (this._updateCallback) this._updateCallback(err);
                 return;
             }
-            this.getACSensorInfo((err, _info) => {
-                this.initUpdateTimeout();
-                if (this._updateCallback) this._updateCallback(err);
+            this.getACDemandControl((err, _info) => {
+                if (err) {
+                    this.initUpdateTimeout();
+                    if (this._updateCallback) this._updateCallback(err);
+                    return;
+                }
+                this.getACSensorInfo((err, _info) => {
+                    this.initUpdateTimeout();
+                    if (this._updateCallback) this._updateCallback(err);
+                });
             });
         });
     }
@@ -167,6 +179,15 @@ export class DaikinAC {
                     if (callback) callback(errFinal, daikinGetResponse);
                 });
             });
+        });
+    }
+
+    public getACDemandControl(callback: defaultCallback<DemandControl>) {
+        this._daikinRequest.getACDemandControl((err, _ret, daikinResponse) => {
+            if (this._logger) this._logger(JSON.stringify(daikinResponse));
+            if (!err) this._currentACDemandControl = daikinResponse;
+
+            if (callback) callback(err, daikinResponse);
         });
     }
 

--- a/src/DaikinAC.ts
+++ b/src/DaikinAC.ts
@@ -50,8 +50,9 @@ export class DaikinAC {
 
     private _currentACModelInfo: null | ModelInfoResponse = null;
     private _currentACControlInfo: null | ControlInfo = null;
-    private _currentACDemandControl: null | DemandControl = null;
     private _currentACSensorInfo: null | SensorInfoResponse = null;
+    private _currentACDemandControl: null | DemandControl = null;
+    private _acDemandControlSupported = true;
 
     private _logger: null | Logger;
     private _daikinRequest: DaikinACRequest;
@@ -110,7 +111,7 @@ export class DaikinAC {
                 return;
             }
             this.getACSensorInfo((err, _info) => {
-                if (err) {
+                if (err || !this._acDemandControlSupported) {
                     this.initUpdateTimeout();
                     if (this._updateCallback) this._updateCallback(err);
                     return;
@@ -185,7 +186,12 @@ export class DaikinAC {
     public getACDemandControl(callback: defaultCallback<DemandControl>) {
         this._daikinRequest.getACDemandControl((err, _ret, daikinResponse) => {
             if (this._logger) this._logger(JSON.stringify(daikinResponse));
-            if (!err) this._currentACDemandControl = daikinResponse;
+            if (!err) {
+                this._currentACDemandControl = daikinResponse;
+            } else {
+                if (this._logger) this._logger(`Disabling demand control support: ${err.message}`);
+                this._acDemandControlSupported = false;
+            }
 
             if (callback) callback(err, daikinResponse);
         });

--- a/src/DaikinAC.ts
+++ b/src/DaikinAC.ts
@@ -116,9 +116,9 @@ export class DaikinAC {
                     if (this._updateCallback) this._updateCallback(err);
                     return;
                 }
-                this.getACDemandControl((err, _info) => {
+                this.getACDemandControl((_err, _info) => {
                     this.initUpdateTimeout();
-                    if (this._updateCallback) this._updateCallback(err);
+                    if (this._updateCallback) this._updateCallback(null);
                 });
             });
         });

--- a/src/DaikinAC.ts
+++ b/src/DaikinAC.ts
@@ -109,13 +109,13 @@ export class DaikinAC {
                 if (this._updateCallback) this._updateCallback(err);
                 return;
             }
-            this.getACDemandControl((err, _info) => {
+            this.getACSensorInfo((err, _info) => {
                 if (err) {
                     this.initUpdateTimeout();
                     if (this._updateCallback) this._updateCallback(err);
                     return;
                 }
-                this.getACSensorInfo((err, _info) => {
+                this.getACDemandControl((err, _info) => {
                     this.initUpdateTimeout();
                     if (this._updateCallback) this._updateCallback(err);
                 });

--- a/src/DaikinACRequest.ts
+++ b/src/DaikinACRequest.ts
@@ -13,6 +13,7 @@ import {
 } from './models';
 import { SetCommandResponse, SetSpecialModeRequest } from './models';
 import { SpecialModeKind } from './DaikinACTypes';
+import { DemandControl } from './models/DemandControl';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const RestClient = require('node-rest-client').Client;
@@ -238,6 +239,13 @@ export class DaikinACRequest {
         } catch (e) {
             callback(e instanceof Error ? e : new Error(e as string), null, null);
         }
+    }
+
+    public getACDemandControl(callback: DaikinResponseCb<DemandControl>) {
+        this.doGet(`http://${this.ip}/aircon/get_demand_control`, {}, (data, _response) => {
+            const dict = DaikinDataParser.processResponse(data, callback);
+            if (dict !== null) DemandControl.parseResponse(dict, callback);
+        });
     }
 
     public getACSensorInfo(callback: DaikinResponseCb<SensorInfoResponse>) {

--- a/src/models/DemandControl.ts
+++ b/src/models/DemandControl.ts
@@ -2,6 +2,7 @@ import { DaikinDataParser, ResponseDict } from '../DaikinDataParser';
 import { DaikinResponseCb } from '../DaikinACRequest';
 
 export class DemandControl {
+    public type?: number;
     public enabled?: boolean;
     public mode?: number;
     public maxPower?: number;
@@ -9,6 +10,7 @@ export class DemandControl {
     // ret=OK,type=1,en_demand=1,mode=0,max_pow=55,scdl_per_day=4,moc=0,tuc=0,wec=0,thc=0,frc=0,sac=0,suc=0
     public static parseResponse(dict: ResponseDict, cb: DaikinResponseCb<DemandControl>): void {
         const result = new DemandControl();
+        result.type = DaikinDataParser.resolveInteger(dict, 'type');
         result.enabled = DaikinDataParser.resolveBool(dict, 'en_demand');
         result.mode = DaikinDataParser.resolveInteger(dict, 'mode');
         result.maxPower = DaikinDataParser.resolveInteger(dict, 'max_pow');

--- a/src/models/DemandControl.ts
+++ b/src/models/DemandControl.ts
@@ -1,0 +1,17 @@
+import { DaikinDataParser, ResponseDict } from '../DaikinDataParser';
+import { DaikinResponseCb } from '../DaikinACRequest';
+
+export class DemandControl {
+    public enabled?: boolean;
+    public mode?: number;
+    public maxPower?: number;
+
+    // ret=OK,type=1,en_demand=1,mode=0,max_pow=55,scdl_per_day=4,moc=0,tuc=0,wec=0,thc=0,frc=0,sac=0,suc=0
+    public static parseResponse(dict: ResponseDict, cb: DaikinResponseCb<DemandControl>): void {
+        const result = new DemandControl();
+        result.enabled = DaikinDataParser.resolveBool(dict, 'en_demand');
+        result.mode = DaikinDataParser.resolveInteger(dict, 'mode');
+        result.maxPower = DaikinDataParser.resolveInteger(dict, 'max_pow');
+        cb(null, 'OK', result);
+    }
+}


### PR DESCRIPTION
Closes #267

For now only the minimum needed for later control is exposed:

- enabled: to be able to activate or deactivate demand control
- mode: to be able to change the modes MANUAL, AUTO (, SCHEDULE)
- max_power: to be able to change maximum power percentage of demand control

Not exposed:

- type: meaning unknown; and must be always 1
- schedule information: support is complex and not really an automation use case in my opinion

Note: DemandControl class is currently trivial, but will be extended later for write support.