### PR TITLE
fix: report unavailable sensor readings as undefined; serialise NaN targets as M

### DIFF
--- a/src/models/ControlInfo.ts
+++ b/src/models/ControlInfo.ts
@@ -146,6 +146,15 @@ export class ControlInfo {
         if (obj.error !== undefined) this.error = obj.error;
     }
 
+    /**
+     * Devices report '--' as the target temperature in modes without a numeric
+     * setpoint (fan/dry), which parses to NaN. Writing NaN back is rejected with
+     * PARAM NG, so serialise it as 'M', the alternative target the device accepts.
+     */
+    private static temperatureTarget(value: number | 'M'): number | 'M' {
+        return typeof value === 'number' && Number.isNaN(value) ? 'M' : value;
+    }
+
     public getRequestDict(): RequestDict {
         const dict: RequestDict = {};
         if (this.power === undefined) throw new Error('Required Field power do not exists');
@@ -155,21 +164,25 @@ export class ControlInfo {
 
         dict['pow'] = this.power ? 1 : 0;
         dict['mode'] = this.mode;
-        dict['stemp'] =
-            typeof this.targetTemperature === 'number'
-                ? (Math.round(this.targetTemperature * 2) / 2).toFixed(1)
-                : this.targetTemperature;
+        const stemp = ControlInfo.temperatureTarget(this.targetTemperature);
+        dict['stemp'] = typeof stemp === 'number' ? (Math.round(stemp * 2) / 2).toFixed(1) : stemp;
 
         dict['shum'] = this.targetHumidity;
         if (this.fanRate !== undefined) dict['f_rate'] = this.fanRate;
         if (this.fanDirection !== undefined) dict['f_dir'] = this.fanDirection;
         if (this.specialMode !== undefined) dict['adv'] = this.specialMode;
-        if (this.targetTemperatureMode1 !== undefined) dict['dt1'] = this.targetTemperatureMode1;
-        if (this.targetTemperatureMode2 !== undefined) dict['dt2'] = this.targetTemperatureMode2;
-        if (this.targetTemperatureMode3 !== undefined) dict['dt3'] = this.targetTemperatureMode3;
-        if (this.targetTemperatureMode4 !== undefined) dict['dt4'] = this.targetTemperatureMode4;
-        if (this.targetTemperatureMode5 !== undefined) dict['dt5'] = this.targetTemperatureMode5;
-        if (this.targetTemperatureMode7 !== undefined) dict['dt7'] = this.targetTemperatureMode7;
+        if (this.targetTemperatureMode1 !== undefined)
+            dict['dt1'] = ControlInfo.temperatureTarget(this.targetTemperatureMode1);
+        if (this.targetTemperatureMode2 !== undefined)
+            dict['dt2'] = ControlInfo.temperatureTarget(this.targetTemperatureMode2);
+        if (this.targetTemperatureMode3 !== undefined)
+            dict['dt3'] = ControlInfo.temperatureTarget(this.targetTemperatureMode3);
+        if (this.targetTemperatureMode4 !== undefined)
+            dict['dt4'] = ControlInfo.temperatureTarget(this.targetTemperatureMode4);
+        if (this.targetTemperatureMode5 !== undefined)
+            dict['dt5'] = ControlInfo.temperatureTarget(this.targetTemperatureMode5);
+        if (this.targetTemperatureMode7 !== undefined)
+            dict['dt7'] = ControlInfo.temperatureTarget(this.targetTemperatureMode7);
         if (this.targetHumidityMode1 !== undefined) dict['dh1'] = this.targetHumidityMode1;
         if (this.targetHumidityMode2 !== undefined) dict['dh2'] = this.targetHumidityMode2;
         if (this.targetHumidityMode3 !== undefined) dict['dh3'] = this.targetHumidityMode3;
@@ -194,7 +207,8 @@ export class ControlInfo {
         if (this.fanDirectionMode7 !== undefined) dict['dfd7'] = this.fanDirectionMode7;
         if (this.fanDirectionModeH !== undefined) dict['dfdh'] = this.fanDirectionModeH;
         if (this.modeB !== undefined) dict['b_mode'] = this.modeB;
-        if (this.targetTemperatureB !== undefined) dict['b_stemp'] = this.targetTemperatureB;
+        if (this.targetTemperatureB !== undefined)
+            dict['b_stemp'] = ControlInfo.temperatureTarget(this.targetTemperatureB);
         if (this.targetHumidityB !== undefined) dict['b_shum'] = this.targetHumidityB;
         if (this.fanRateB !== undefined) dict['b_f_rate'] = this.fanRateB;
         if (this.fanDirectionB !== undefined) dict['b_f_dir'] = this.fanDirectionB;

--- a/src/models/responses/SensorInfoResponse.ts
+++ b/src/models/responses/SensorInfoResponse.ts
@@ -1,6 +1,12 @@
 import { DaikinDataParser, ResponseDict } from '../../DaikinDataParser';
 import { DaikinResponseCb } from '../../DaikinACRequest';
 
+// Devices report '-' for sensor readings they cannot provide; that parses to NaN.
+function resolveSensorReading(dict: ResponseDict, key: string): number | undefined {
+    const value = DaikinDataParser.resolveFloat<number>(dict, key);
+    return typeof value === 'number' && Number.isNaN(value) ? undefined : value;
+}
+
 export class SensorInfoResponse {
     public indoorTemperature?: number;
     public indoorHumidity?: number;
@@ -10,9 +16,9 @@ export class SensorInfoResponse {
 
     public static parseResponse(dict: ResponseDict, cb: DaikinResponseCb<SensorInfoResponse>): void {
         const result = new SensorInfoResponse();
-        result.indoorTemperature = DaikinDataParser.resolveFloat(dict, 'htemp');
-        result.indoorHumidity = DaikinDataParser.resolveFloat(dict, 'hhum');
-        result.outdoorTemperature = DaikinDataParser.resolveFloat(dict, 'otemp');
+        result.indoorTemperature = resolveSensorReading(dict, 'htemp');
+        result.indoorHumidity = resolveSensorReading(dict, 'hhum');
+        result.outdoorTemperature = resolveSensorReading(dict, 'otemp');
         result.error = DaikinDataParser.resolveInteger(dict, 'err');
         result.cmpfreq = DaikinDataParser.resolveInteger(dict, 'cmpfreq');
         cb(null, 'OK', result);

--- a/test/testDaikinAC.test.ts
+++ b/test/testDaikinAC.test.ts
@@ -237,7 +237,7 @@ describe('Test DaikinAC', () => {
                     expect(err).toBeNull();
                     expect(Object.keys(response!).length).toEqual(5);
                     expect(response!.indoorTemperature).toEqual(21.5);
-                    expect(response!.outdoorTemperature).toBeNaN();
+                    expect(response!.outdoorTemperature).toBeUndefined();
 
                     daikin.getACModelInfo(function (err, response) {
                         expect(err).toBeNull();
@@ -300,5 +300,5 @@ describe('Test DaikinAC', () => {
                 });
             });
         });
-    }, 600000);
+    }, 10000);
 });

--- a/test/testDaikinACGet.test.ts
+++ b/test/testDaikinACGet.test.ts
@@ -127,6 +127,41 @@ describe('Test DaikinAC', function () {
             });
         });
     });
+    it('constructor and setACControlInfo power-off merge in fan mode', function (done) {
+        const req = nock('http://127.0.0.1')
+            .get('/common/basic_info')
+            .reply(
+                200,
+                'ret=OK,type=aircon,reg=eu,dst=1,ver=2_6_0,pow=1,err=0,location=0,name=%4b%6c%69%6d%61%20%4a%61%6e%61,icon=0,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=2,pv=0,cpv=0,cpv_minor=00,led=0,en_setzone=1,mac=A408EACC91D4,adp_mode=run,en_hol=0,grp_name=%4b%69%6e%64%65%72,en_grp=1',
+            )
+            .get('/aircon/get_model_info')
+            .reply(200, 'ret=OK,model=NOTSUPPORT,type=N,pv=0,cpv=0,mid=NA,s_fdir=1,en_scdltmr=1')
+            .get('/aircon/get_control_info')
+            .reply(
+                200,
+                'ret=OK,pow=1,mode=6,adv=,stemp=--,shum=0,dt1=25.0,dt2=M,dt3=23.0,dt4=27.0,dt5=27.0,dt7=25.0,dh1=AUTO,dh2=50,dh3=0,dh4=0,dh5=0,dh7=AUTO,dhh=50,b_mode=6,b_stemp=--,b_shum=0,alert=255,f_rate=A,f_dir=0,b_f_rate=A,b_f_dir=0,dfr1=5,dfr2=5,dfr3=A,dfr4=5,dfr5=5,dfr6=5,dfr7=5,dfrh=5,dfd1=0,dfd2=0,dfd3=0,dfd4=0,dfd5=0,dfd6=0,dfd7=0,dfdh=0',
+            )
+            .get(
+                '/aircon/set_control_info?pow=0&mode=6&stemp=M&shum=0&f_rate=A&f_dir=0&adv=&dt1=25&dt2=M&dt3=23&dt4=27&dt5=27&dt7=25&dh1=AUTO&dh2=50&dh3=0&dh4=0&dh5=0&dh7=AUTO&dhh=50&dfr1=5&dfr2=5&dfr3=A&dfr4=5&dfr5=5&dfr6=5&dfr7=5&dfrh=5&dfd1=0&dfd2=0&dfd3=0&dfd4=0&dfd5=0&dfd6=0&dfd7=0&dfdh=0&b_mode=6&b_stemp=M&b_shum=0&b_f_rate=A&b_f_dir=0&alert=255',
+            )
+            .reply(200, 'ret=OK,adv=')
+            .get('/aircon/get_control_info')
+            .reply(
+                200,
+                'ret=OK,pow=0,mode=6,adv=,stemp=--,shum=0,dt1=25.0,dt2=M,dt3=23.0,dt4=27.0,dt5=27.0,dt7=25.0,dh1=AUTO,dh2=50,dh3=0,dh4=0,dh5=0,dh7=AUTO,dhh=50,b_mode=6,b_stemp=--,b_shum=0,alert=255,f_rate=A,f_dir=0,b_f_rate=A,b_f_dir=0,dfr1=5,dfr2=5,dfr3=A,dfr4=5,dfr5=5,dfr6=5,dfr7=5,dfrh=5,dfd1=0,dfd2=0,dfd3=0,dfd4=0,dfd5=0,dfd6=0,dfd7=0,dfdh=0',
+            );
+        const daikin = new DaikinAC('127.0.0.1', options, function (err) {
+            expect(err).toBeNull();
+            daikin.setACControlInfo({ power: false } as ControlInfo, function (err, response) {
+                expect(err).toBeNull();
+                expect(req.isDone()).toBeTruthy();
+                expect(response!.power).toBeFalsy();
+                expect(response!.mode).toEqual(6);
+                done();
+            });
+        });
+    });
+
     it('constructor and failure1 setACControlInfo', function (done) {
         nock('http://127.0.0.1')
             .get('/common/basic_info')

--- a/test/testDaikinACGet.test.ts
+++ b/test/testDaikinACGet.test.ts
@@ -229,7 +229,7 @@ describe('Test DaikinAC', function () {
                     expect(err).toBeNull();
                     expect(Object.keys(response!).length).toEqual(5);
                     expect(response!.indoorTemperature).toEqual(21.5);
-                    expect(response!.outdoorTemperature).toBeNaN();
+                    expect(response!.outdoorTemperature).toBeUndefined();
 
                     daikin.getACModelInfo(function (err, response) {
                         expect(err).toBeNull();

--- a/test/testDaikinACRequestGet.test.ts
+++ b/test/testDaikinACRequestGet.test.ts
@@ -54,6 +54,21 @@ describe('Test DaikinACTypes', () => {
         done();
     });
 
+    it('getRequestDict serialises NaN temperature targets as M', (done) => {
+        const info = new ControlInfo();
+        info.power = false;
+        info.mode = 6;
+        info.targetTemperature = NaN;
+        info.targetHumidity = 0;
+        info.targetTemperatureMode1 = NaN;
+        info.targetTemperatureB = NaN;
+        const res = info.getRequestDict();
+        expect(res.stemp).toEqual('M');
+        expect(res.dt1).toEqual('M');
+        expect(res.b_stemp).toEqual('M');
+        done();
+    });
+
     it('set_control_info Success', (done) => {
         const info = new ControlInfo();
         info.power = false;

--- a/test/testDaikinACRequestGet.test.ts
+++ b/test/testDaikinACRequestGet.test.ts
@@ -131,6 +131,23 @@ describe('Test DaikinACTypes', () => {
         });
     });
 
+    it('get_sensor_info reports unavailable readings as undefined', (done) => {
+        const req = nock('http://127.0.0.1')
+            .get('/aircon/get_sensor_info')
+            .reply(200, 'ret=OK,htemp=-,hhum=-,otemp=10.0,err=0,cmpfreq=0');
+        const daikin = new DaikinACRequest('127.0.0.1', { useGetToPost: true });
+        daikin.getACSensorInfo((err, ret, daikinResponse) => {
+            expect(req.isDone()).toBeTruthy();
+            expect(err).toBeNull();
+            expect(ret).toEqual('OK');
+            expect(daikinResponse!.indoorTemperature).toBeUndefined();
+            expect(daikinResponse!.indoorHumidity).toBeUndefined();
+            expect(daikinResponse!.outdoorTemperature).toEqual(10);
+            expect(daikinResponse!.error).toEqual(0);
+            done();
+        });
+    });
+
     it('set_special_mode Error Adv', (done) => {
         const specialMode = new SetSpecialModeRequest(SpecialModeState.ON, SpecialModeKind.POWERFUL);
         const req = nock('http://127.0.0.1')


### PR DESCRIPTION
Two small parser/serialiser fixes, split out of the HTTPS work mentioned in #321 as they apply to the existing HTTP transport as-is.

## What

- **Unavailable sensor readings surface as `undefined` instead of `NaN`.** Devices reply with `-` for values they cannot provide (`otemp`/`hhum` on units without those sensors, or `htemp` shortly after power-up). `parseFloat('-')` yields `NaN`, which leaked into display and arithmetic; the response fields are typed optional, so consumers reasonably check for `undefined`. Scoped to sensor parsing only — ControlInfo's alternative-value handling (`M`, `AUTO`) is unchanged.
- **`NaN` temperature targets serialise as `M`.** When a unit is in a mode with no numeric target, writing the control info back sent `stemp=NaN`, which the unit rejects with `PARAM NG`; it now round-trips as `M`, matching what the unit itself reports.

Also updates the getMethods test, which pinned the old NaN behaviour and carried a 600s timeout (a failure inside its callback chain used to hang rather than fail; it now expects `undefined` and fails within 10s).

## Testing

- New regression tests for both behaviours (`get_sensor_info` with `htemp=-`/`hhum=-`, `set_control_info` round-trip of an `M` target).
- Full jest suite green on Node 20 and 22.
- Running in production against six BRP072C42-equipped units.

Happy to adjust to any conventions I've missed.